### PR TITLE
Fraction.TryParse improvements

### DIFF
--- a/src/Primitives/Primitives/src/Fraction.cs
+++ b/src/Primitives/Primitives/src/Fraction.cs
@@ -26,12 +26,17 @@
 
         public static bool TryParse(string str, out Fraction fraction)
         {
+            return TryParse(str, new[] {'/', ':'}, out fraction);
+        }
+
+        public static bool TryParse(string str, char[] separators, out Fraction fraction)
+        {
             fraction = new Fraction();
 
             if (string.IsNullOrWhiteSpace(str))
                 return false;
 
-            var pieces = str.Split('/');
+            var pieces = str.Split(separators);
             if (pieces.Length < 1 || pieces.Length > 2)
                 return false;
 

--- a/src/Primitives/Primitives/test/FractionTests.cs
+++ b/src/Primitives/Primitives/test/FractionTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace ClickView.Extensions.Primitives.Tests
 {
+    using System;
     using Xunit;
 
     public class FractionTests
@@ -11,8 +12,6 @@
 
             Assert.True(Fraction.TryParse(str, out var fraction));
 
-            Assert.Equal((double)100/11, fraction);
-            Assert.Equal(str, fraction.ToString());
             Assert.Equal(100, fraction.Numerator);
             Assert.Equal(11, fraction.Denominator);
         }
@@ -24,8 +23,6 @@
 
             Assert.True(Fraction.TryParse(str, out var fraction));
 
-            Assert.Equal((double)100, fraction);
-            Assert.Equal("100", fraction.ToString());
             Assert.Equal(100, fraction.Numerator);
             Assert.Equal(1, fraction.Denominator);
         }
@@ -44,6 +41,48 @@
         {
             Assert.Equal(new Fraction(123, 123), new Fraction(123, 123));
             Assert.Equal(new Fraction(2, 4), new Fraction(4, 8));
+        }
+
+        [Fact]
+        public void Can_Parse_WithSemicolon()
+        {
+            const string str = "100:11";
+
+            Assert.True(Fraction.TryParse(str, out var fraction));
+
+            Assert.Equal((double)100 / 11, fraction);
+            Assert.Equal(100, fraction.Numerator);
+            Assert.Equal(11, fraction.Denominator);
+        }
+
+        [Fact]
+        public void ToString_With_Denominator()
+        {
+            var fraction = new Fraction(100, 99);
+
+            Assert.Equal("100/99", fraction.ToString());
+        }
+
+        [Fact]
+        public void ToString_Without_Denominator()
+        {
+            var fraction = new Fraction(100);
+
+            Assert.Equal("100", fraction.ToString());
+        }
+
+        [Fact]
+        public void Implicit_Operator_Double()
+        {
+            var fraction = new Fraction(100, 11);
+
+            Assert.Equal((double)100 / 11, fraction);
+        }
+
+        [Fact]
+        public void Constructor_ZeroDenominator_ThrowsArgumentException()
+        {
+            Assert.Throws<ArgumentException>(() => new Fraction(100, 0));
         }
     }
 }


### PR DESCRIPTION
Updates to `Fraction.TryParse`:
- Handle fractions with a `:` separator
- Allow specifying custom fraction separators 

Also cleaned up the fraction tests a little