### PR TITLE
Added CancellationToken support to the RestClient and Authenticators

### DIFF
--- a/src/RestClient/Authenticators/OAuth/src/Authenticators/ClientCredentialsTokenSource.cs
+++ b/src/RestClient/Authenticators/OAuth/src/Authenticators/ClientCredentialsTokenSource.cs
@@ -1,6 +1,7 @@
 ﻿namespace ClickView.Extensions.RestClient.Authenticators.OAuth.Authenticators
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Logging;
     using Tokens;
@@ -20,9 +21,9 @@
             _logger = loggerFactory.CreateLogger<ClientCredentialsTokenSource>();
         }
 
-        protected override async Task<AccessToken> GetAccessTokenAsync()
+        protected override async Task<AccessToken> GetAccessTokenAsync(CancellationToken cancellationToken = default)
         {
-            var response = await _tokenClient.GetClientCredentialsTokenAsync(_scope).ConfigureAwait(false);
+            var response = await _tokenClient.GetClientCredentialsTokenAsync(_scope, cancellationToken);
 
             //todo: handle errors
             if (!response.IsError)

--- a/src/RestClient/Authenticators/OAuth/src/TokenClient.cs
+++ b/src/RestClient/Authenticators/OAuth/src/TokenClient.cs
@@ -1,6 +1,7 @@
 ﻿namespace ClickView.Extensions.RestClient.Authenticators.OAuth
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using IdentityModel.Client;
     using Internal.Endpoints;
@@ -20,7 +21,7 @@
             _endpointFactory = endpointFactory;
         }
 
-        public async Task<TokenResponse> GetClientCredentialsTokenAsync(string scope)
+        public async Task<TokenResponse> GetClientCredentialsTokenAsync(string scope, CancellationToken cancellationToken = default)
         {
             var endpoints = await _endpointFactory.GetAsync().ConfigureAwait(false);
 
@@ -30,10 +31,10 @@
                 ClientSecret = _clientSecret,
                 Scope = scope,
                 Address = endpoints.TokenEndpoint
-            }).ConfigureAwait(false);
+            }, cancellationToken).ConfigureAwait(false);
         }
 
-        public async Task<TokenResponse> GetRefreshTokenAsync(string refreshToken)
+        public async Task<TokenResponse> GetRefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default)
         {
             var endpoints = await _endpointFactory.GetAsync().ConfigureAwait(false);
 
@@ -41,7 +42,7 @@
             {
                 Address = endpoints.TokenEndpoint,
                 RefreshToken = refreshToken
-            }).ConfigureAwait(false);
+            }, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/RestClient/Authenticators/OAuth/src/TokenSource/AccessTokenSource.cs
+++ b/src/RestClient/Authenticators/OAuth/src/TokenSource/AccessTokenSource.cs
@@ -1,14 +1,15 @@
 ﻿namespace ClickView.Extensions.RestClient.Authenticators.OAuth.TokenSource
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Tokens;
 
     public abstract class AccessTokenSource : ITokenSource
     {
-        public async Task<IReadOnlyCollection<Token>> GetTokensAsync()
+        public async Task<IReadOnlyCollection<Token>> GetTokensAsync(CancellationToken cancellationToken = default)
         {
-            var token = await GetAccessTokenAsync().ConfigureAwait(false);
+            var token = await GetAccessTokenAsync(cancellationToken).ConfigureAwait(false);
 
             if (token == null)
                 return new List<Token>();
@@ -18,6 +19,6 @@
 
         public virtual bool StoreTokens => true;
 
-        protected abstract Task<AccessToken> GetAccessTokenAsync();
+        protected abstract Task<AccessToken> GetAccessTokenAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/RestClient/Authenticators/OAuth/src/TokenSource/ITokenSource.cs
+++ b/src/RestClient/Authenticators/OAuth/src/TokenSource/ITokenSource.cs
@@ -1,6 +1,7 @@
 ﻿namespace ClickView.Extensions.RestClient.Authenticators.OAuth.TokenSource
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Tokens;
 
@@ -11,6 +12,6 @@
         /// </summary>
         bool StoreTokens { get; }
 
-        Task<IReadOnlyCollection<Token>> GetTokensAsync();
+        Task<IReadOnlyCollection<Token>> GetTokensAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/RestClient/Authenticators/OAuth/src/TokenSource/RefreshTokenSource.cs
+++ b/src/RestClient/Authenticators/OAuth/src/TokenSource/RefreshTokenSource.cs
@@ -1,6 +1,7 @@
 ﻿namespace ClickView.Extensions.RestClient.Authenticators.OAuth.TokenSource
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Extensions.Logging;
     using Tokens;
@@ -19,7 +20,7 @@
             _logger = loggerFactory.CreateLogger<RefreshTokenSource>();
         }
 
-        public async Task<IReadOnlyCollection<Token>> GetTokensAsync()
+        public async Task<IReadOnlyCollection<Token>> GetTokensAsync(CancellationToken cancellationToken = default)
         {
             var refreshToken = await _tokenStore.GetTokenAsync(TokenType.RefreshToken).ConfigureAwait(false);
             if (refreshToken == null)
@@ -28,7 +29,7 @@
             _logger.LogDebug("Refreshing token");
 
             var refreshTokenResponse =
-                await _tokenClient.GetRefreshTokenAsync(refreshToken.Value).ConfigureAwait(false);
+                await _tokenClient.GetRefreshTokenAsync(refreshToken.Value, cancellationToken).ConfigureAwait(false);
 
             //todo: handle errors
             if (refreshTokenResponse.IsError)

--- a/src/RestClient/Authenticators/OAuth/src/TokenSource/TokenStoreTokenSource.cs
+++ b/src/RestClient/Authenticators/OAuth/src/TokenSource/TokenStoreTokenSource.cs
@@ -1,6 +1,7 @@
 ﻿namespace ClickView.Extensions.RestClient.Authenticators.OAuth.TokenSource
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Tokens;
     using TokenStore;
@@ -14,7 +15,7 @@
             _tokenStore = tokenStore;
         }
 
-        public async Task<IReadOnlyCollection<Token>> GetTokensAsync()
+        public async Task<IReadOnlyCollection<Token>> GetTokensAsync(CancellationToken cancellationToken = default)
         {
             var token = await _tokenStore.GetTokenAsync(TokenType.AccessToken).ConfigureAwait(false);
 

--- a/src/RestClient/RestClient/src/Authentication/HeaderAuthenticator.cs
+++ b/src/RestClient/RestClient/src/Authentication/HeaderAuthenticator.cs
@@ -1,5 +1,6 @@
 ﻿namespace ClickView.Extensions.RestClient.Authentication
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Requests;
 
@@ -17,7 +18,7 @@
             _value = value;
         }
 
-        public Task AuthenticateAsync(IClientRequest request)
+        public Task AuthenticateAsync(IClientRequest request, CancellationToken token = default)
         {
             request.AddHeader(_key, _value);
 

--- a/src/RestClient/RestClient/src/Authentication/IAuthenticator.cs
+++ b/src/RestClient/RestClient/src/Authentication/IAuthenticator.cs
@@ -1,10 +1,11 @@
 ﻿namespace ClickView.Extensions.RestClient.Authentication
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Requests;
 
     public interface IAuthenticator
     {
-        Task AuthenticateAsync(IClientRequest request);
+        Task AuthenticateAsync(IClientRequest request, CancellationToken token = default);
     }
 }


### PR DESCRIPTION
This is a breaking change to libraries which inherit from:
- `IAuthenticator`
- `ITokenSource`

I have not included `CancellationToken` support for `ITokenStore` in this commit. We can add this later if needed