### PR TITLE
Added TaskSingle class

### DIFF
--- a/src/Utilities/Utilities/src/Threading/TaskSingle.cs
+++ b/src/Utilities/Utilities/src/Threading/TaskSingle.cs
@@ -1,0 +1,78 @@
+﻿namespace ClickView.Extensions.Utilities.Threading
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public sealed class TaskSingle
+    {
+        /// <summary>
+        /// A default instance of TaskSingle using String as the key type
+        /// </summary>
+        public static TaskSingle<string> Default = new TaskSingle<string>();
+    }
+
+    /// <summary>
+    /// A helper class which provides duplicate function call suppression
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    public sealed class TaskSingle<TKey>
+    {
+        private readonly Dictionary<TKey, object> _completionTasks = new Dictionary<TKey, object>();
+
+        /// <summary>
+        /// Executes the action returning the result. Only one action will run concurrently per <param name="key">key</param>
+        /// </summary>
+        /// <typeparam name="TVal"></typeparam>
+        /// <param name="key">A unique key which is used to identity the work to be executed</param>
+        /// <param name="func">The work to execute asynchronously</param>
+        /// <returns></returns>
+        public Task<TVal> RunAsync<TVal>(TKey key, Func<Task<TVal>> func)
+        {
+            lock (_completionTasks)
+            {
+                if (_completionTasks.TryGetValue(key, out var value))
+                {
+                    var tcs = (TaskCompletionSource<TVal>)value;
+
+                    Task.Run(() => { });
+
+                    return tcs.Task;
+                }
+                else
+                {
+                    var tcs = new TaskCompletionSource<TVal>();
+
+                    _ = Runner(key, tcs, func);
+
+                    _completionTasks.Add(key, tcs);
+
+                    return tcs.Task;
+                }
+            }
+        }
+
+        private async Task Runner<TVal>(TKey key, TaskCompletionSource<TVal> tcs, Func<Task<TVal>> func)
+        {
+            try
+            {
+                var result = await func();
+
+                tcs.SetResult(result);
+            }
+            catch (OperationCanceledException)
+            {
+                tcs.SetCanceled();
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+
+            lock (_completionTasks)
+            {
+                _completionTasks.Remove(key);
+            }
+        }
+    }
+}

--- a/src/Utilities/Utilities/src/Threading/TaskSingleExtensions.cs
+++ b/src/Utilities/Utilities/src/Threading/TaskSingleExtensions.cs
@@ -1,0 +1,25 @@
+﻿namespace ClickView.Extensions.Utilities.Threading
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public static class TaskSingleExtensions
+    {
+        /// <summary>
+        /// Executes the action returning the result. Only one action will run concurrently per <param name="key">key</param>
+        /// </summary>
+        /// <typeparam name="TKey"></typeparam>
+        /// <typeparam name="TVal"></typeparam>
+        /// <param name="instance"></param>
+        /// <param name="key">A unique key which is used to identity the work to be executed</param>
+        /// <param name="func">The work to execute asynchronously</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public static Task<TVal> RunAsync<TKey, TVal>(this TaskSingle<TKey> instance, TKey key,
+            Func<TKey, CancellationToken, Task<TVal>> func, CancellationToken cancellationToken = default)
+        {
+            return instance.RunAsync(key, () => func(key, cancellationToken));
+        }
+    }
+}

--- a/src/Utilities/Utilities/test/ClickView.Extensions.Utilities.Tests/Threading/TaskSingleTest.cs
+++ b/src/Utilities/Utilities/test/ClickView.Extensions.Utilities.Tests/Threading/TaskSingleTest.cs
@@ -1,0 +1,85 @@
+﻿namespace ClickView.Extensions.Utilities.Tests.Threading
+{
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Utilities.Threading;
+    using Xunit;
+
+    public class TaskSingleTest
+    {
+        [Fact]
+        public async Task RunAsync_SameKey_MultipleCalls_RunOnce()
+        {
+            var instance = new TaskSingle<string>();
+
+            var timesRun = 0;
+
+            async Task<string> ThingToRunAsync(string key)
+            {
+                Interlocked.Increment(ref timesRun);
+
+                await Task.Delay(200);
+
+                return key;
+            }
+
+            var results = await Task.WhenAll(
+                instance.RunAsync("test", (s, token) => ThingToRunAsync(s), CancellationToken.None),
+                instance.RunAsync("test", (s, token) => ThingToRunAsync(s), CancellationToken.None),
+                instance.RunAsync("test", (s, token) => ThingToRunAsync(s), CancellationToken.None)
+            );
+
+            Assert.Equal(1, timesRun);
+            Assert.Single(results.Distinct());
+        }
+
+        [Fact]
+        public async Task RunAsync_MultipleKeys_RunManyTimes()
+        {
+            var instance = new TaskSingle<string>();
+
+            var timesRun = 0;
+
+            async Task<string> ThingToRunAsync(string key)
+            {
+                Interlocked.Increment(ref timesRun);
+
+                await Task.Delay(200);
+
+                return key;
+            }
+
+            var results = await Task.WhenAll(
+                instance.RunAsync("test1", (s, token) => ThingToRunAsync(s), CancellationToken.None),
+                instance.RunAsync("test2", (s, token) => ThingToRunAsync(s), CancellationToken.None),
+                instance.RunAsync("test3", (s, token) => ThingToRunAsync(s), CancellationToken.None)
+            );
+
+            Assert.Equal(3, timesRun);
+            Assert.Equal(3, results.Distinct().Count());
+        }
+
+        [Fact]
+        public async Task RunAsync_SameKey_NonParallel()
+        {
+            var instance = new TaskSingle<string>();
+
+            var timesRun = 0;
+
+            async Task<string> ThingToRunAsync(string key)
+            {
+                Interlocked.Increment(ref timesRun);
+
+                await Task.Delay(200);
+
+                return key;
+            }
+
+            await instance.RunAsync("test", (s, token) => ThingToRunAsync(s), CancellationToken.None);
+            await instance.RunAsync("test", (s, token) => ThingToRunAsync(s), CancellationToken.None);
+
+            Assert.Equal(2, timesRun);
+        }
+    }
+}


### PR DESCRIPTION
A helper class to prevent an action being called concurrently. 

A useful implementation would be for querying a redis cache for a certain key as you don't need the same query to run twice at the same time.