### PR TITLE
Add option to not throw on non successful status code

### DIFF
--- a/src/RestClient/RestClient/src/Http/CoreRestClientOptions.cs
+++ b/src/RestClient/RestClient/src/Http/CoreRestClientOptions.cs
@@ -6,5 +6,7 @@ namespace ClickView.Extensions.RestClient.Http
     {
         public CompressionMethod CompressionMethod { get; set; } = CompressionMethod.None;
         public IAuthenticator Authenticator { get; set; } = null;
+
+        public bool ThrowOnErrorStatusCode { get; set; } = true;
     }
 }

--- a/src/RestClient/RestClient/src/Requests/BaseRestClientRequest.cs
+++ b/src/RestClient/RestClient/src/Requests/BaseRestClientRequest.cs
@@ -113,14 +113,15 @@ namespace ClickView.Extensions.RestClient.Requests
             list.AddRange(values.Select(v => new RequestParameterValue(v, RequestParameterType.Query)));
         }
 
-        internal async Task<TResponse> GetResponseAsync(HttpResponseMessage message)
+        internal async Task<TResponse> GetResponseAsync(HttpResponseMessage message, bool throwOnErrorStatusCode)
         {
             var response = await ParseResponseAsync(message).ConfigureAwait(false);
             var error = await GetErrorAsync(message).ConfigureAwait(false);
 
             if (error != null)
             {
-                HandleError(error);
+                if(throwOnErrorStatusCode)
+                    HandleError(error);
 
                 response.Error = error;
             }

--- a/src/RestClient/RestClient/src/RestClient.cs
+++ b/src/RestClient/RestClient/src/RestClient.cs
@@ -1,7 +1,9 @@
 ﻿namespace ClickView.Extensions.RestClient
 {
     using System;
+    using System.IO;
     using System.Net.Http;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Exceptions;
@@ -82,7 +84,7 @@
                 {
                     using (var response = await _httpClient.SendAsync(httpRequest, token).ConfigureAwait(false))
                     {
-                        return await request.GetResponseAsync(response).ConfigureAwait(false);
+                        return await request.GetResponseAsync(response, _options.ThrowOnErrorStatusCode).ConfigureAwait(false);
                     }
                 }
                 catch (HttpRequestException e)


### PR DESCRIPTION
Allow user to pass option to suppress exceptions on a non 200 request.

This is useful when trying to access the body of the request.