### PR TITLE
Async fixes

### DIFF
--- a/src/Hosting/Hosting/src/Workers/Worker.cs
+++ b/src/Hosting/Hosting/src/Workers/Worker.cs
@@ -50,7 +50,7 @@
             _cts.Cancel();
 
             // Wait until the task completes or the stop token triggers
-            await Task.WhenAny(_executingTask, Task.Delay(-1, cancellationToken));
+            await Task.WhenAny(_executingTask, Task.Delay(-1, cancellationToken)).ConfigureAwait(false);
 
             _logger.LogInformation("Worker {WorkerName} stopped", Name);
 

--- a/src/RestClient/Authenticators/OAuth.AspNetCore/src/HttpContextTokenStore.cs
+++ b/src/RestClient/Authenticators/OAuth.AspNetCore/src/HttpContextTokenStore.cs
@@ -34,7 +34,7 @@
         }
 
         //Token reference https://github.com/aspnet/AspNetCore/blob/master/src/Security/Authentication/OAuth/src/OAuthHandler.cs#L116
-        public async Task StoreTokens(IEnumerable<Token> tokens)
+        public async Task StoreTokensAsync(IEnumerable<Token> tokens)
         {
             var httpContext = GetHttpContext();
             var authResult = await httpContext.AuthenticateAsync().ConfigureAwait(false);

--- a/src/RestClient/Authenticators/OAuth/src/OAuthAuthenticator.cs
+++ b/src/RestClient/Authenticators/OAuth/src/OAuthAuthenticator.cs
@@ -97,7 +97,7 @@
                     if (TokenStore == null)
                         throw new OAuthAuthenticatorException("No TokenStore configured");
 
-                    await TokenStore.StoreTokens(tokens).ConfigureAwait(false);
+                    await TokenStore.StoreTokensAsync(tokens).ConfigureAwait(false);
                 }
 
                 return accessToken.Value;

--- a/src/RestClient/Authenticators/OAuth/src/TokenStore/ITokenStore.cs
+++ b/src/RestClient/Authenticators/OAuth/src/TokenStore/ITokenStore.cs
@@ -7,6 +7,6 @@
     public interface ITokenStore
     {
         Task<Token> GetTokenAsync(TokenType tokenType);
-        Task StoreTokens(IEnumerable<Token> tokens);
+        Task StoreTokensAsync(IEnumerable<Token> tokens);
     }
 }

--- a/src/RestClient/Authenticators/OAuth/src/TokenStore/InMemoryTokenStore.cs
+++ b/src/RestClient/Authenticators/OAuth/src/TokenStore/InMemoryTokenStore.cs
@@ -15,7 +15,7 @@
             return Task.FromResult(token);
         }
 
-        public Task StoreTokens(IEnumerable<Token> tokens)
+        public Task StoreTokensAsync(IEnumerable<Token> tokens)
         {
             foreach (var t in tokens)
             {

--- a/src/RestClient/RestClient/src/Http/CompressedContent.cs
+++ b/src/RestClient/RestClient/src/Http/CompressedContent.cs
@@ -5,6 +5,7 @@
     using System.IO.Compression;
     using System.Net;
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
 
     public class CompressedContent : HttpContent
@@ -15,7 +16,7 @@
         public CompressedContent(HttpContent content, CompressionMethod compressionMethod)
         {
             if (compressionMethod == CompressionMethod.None)
-                throw new ArgumentNullException(nameof(compressionMethod));
+                throw new ArgumentException("Invalid CompressionMethod", nameof(compressionMethod));
 
             _originalContent = content ?? throw new ArgumentNullException(nameof(content));
             _compressionMethod = compressionMethod;
@@ -53,7 +54,10 @@
             }
 
             return _originalContent.CopyToAsync(compressedStream, context)
-                .ContinueWith(_ => compressedStream?.Dispose());
+                .ContinueWith(_ => compressedStream?.Dispose(),
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
         }
     }
 }

--- a/src/Utilities/Utilities/src/Threading/TaskSingle.cs
+++ b/src/Utilities/Utilities/src/Threading/TaskSingle.cs
@@ -35,15 +35,13 @@
                 {
                     var tcs = (TaskCompletionSource<TVal>)value;
 
-                    Task.Run(() => { });
-
                     return tcs.Task;
                 }
                 else
                 {
                     var tcs = new TaskCompletionSource<TVal>();
 
-                    _ = Runner(key, tcs, func);
+                    _ = RunAsync(key, tcs, func);
 
                     _completionTasks.Add(key, tcs);
 
@@ -52,11 +50,11 @@
             }
         }
 
-        private async Task Runner<TVal>(TKey key, TaskCompletionSource<TVal> tcs, Func<Task<TVal>> func)
+        private async Task RunAsync<TVal>(TKey key, TaskCompletionSource<TVal> tcs, Func<Task<TVal>> func)
         {
             try
             {
-                var result = await func();
+                var result = await func().ConfigureAwait(false);
 
                 tcs.SetResult(result);
             }


### PR DESCRIPTION
- Adding missing ConfigureAwait
- Making sure all async methods are suffixed with Async
- When using ContinueWith, don't use the overload defaults
- Removed Extra Task.Run from TaskSingle