### PR TITLE
Build absolute urls in the RestClient

### DIFF
--- a/ClickView.Extensions.sln
+++ b/ClickView.Extensions.sln
@@ -77,6 +77,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClickView.Extensions.Health
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClickView.Extensions.HealthCheck.Sql", "src\HealthCheck\Sql\src\ClickView.Extensions.HealthCheck.Sql.csproj", "{C32A4655-B6FA-4CC2-98D9-50DF19098A60}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClickView.Extensions.RestClient.Tests", "src\RestClient\RestClient\test\ClickView.Extensions.RestClient.Tests.csproj", "{051B6555-18CA-45A6-984A-BC0818432A20}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -151,6 +153,10 @@ Global
 		{C32A4655-B6FA-4CC2-98D9-50DF19098A60}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C32A4655-B6FA-4CC2-98D9-50DF19098A60}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C32A4655-B6FA-4CC2-98D9-50DF19098A60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{051B6555-18CA-45A6-984A-BC0818432A20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{051B6555-18CA-45A6-984A-BC0818432A20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{051B6555-18CA-45A6-984A-BC0818432A20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{051B6555-18CA-45A6-984A-BC0818432A20}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -177,6 +183,7 @@ Global
 		{EEBF3C4F-9924-4A7D-A42C-8CA0A78DCEAE} = {83C18C61-AA26-4C00-A35A-49EFAC318D76}
 		{1C7485D4-CEE7-4ADA-A32A-C4437F7D2EC2} = {83C18C61-AA26-4C00-A35A-49EFAC318D76}
 		{C32A4655-B6FA-4CC2-98D9-50DF19098A60} = {83C18C61-AA26-4C00-A35A-49EFAC318D76}
+		{051B6555-18CA-45A6-984A-BC0818432A20} = {BD0881FC-4083-49F5-B108-2205C691A9E4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3A15E820-F957-4F4D-AE2F-6EF055C27DB8}

--- a/src/RestClient/RestClient/src/RestClient.cs
+++ b/src/RestClient/RestClient/src/RestClient.cs
@@ -16,6 +16,11 @@
         private readonly HttpClient _httpClient;
         private readonly CoreRestClientOptions _options;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RestClient" /> class
+        /// </summary>
+        /// <param name="baseAddress"></param>
+        /// <param name="options"></param>
         public RestClient(Uri baseAddress, RestClientOptions options = null)
         {
             _baseAddress = baseAddress ?? throw new ArgumentNullException(nameof(baseAddress));
@@ -55,6 +60,16 @@
             _baseAddress = baseAddress ?? throw new ArgumentNullException(nameof(baseAddress));
         }
 
+        /// <summary>
+        /// Executes a <see cref="RestClientRequest{TData}"/>
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="token"></param>
+        /// <typeparam name="TResponse"></typeparam>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="InvalidOperationException"></exception>
+        /// <exception cref="ClickViewClientException"></exception>
         public async Task<TResponse> ExecuteAsync<TResponse>(BaseRestClientRequest<TResponse> request, CancellationToken token = default)
             where TResponse : RestClientResponse
         {

--- a/src/RestClient/RestClient/src/RestClient.cs
+++ b/src/RestClient/RestClient/src/RestClient.cs
@@ -72,20 +72,25 @@
                 QueryHelpers.AddQueryString(request.Resource, request.Parameters),
                 UriKind.RelativeOrAbsolute);
 
-            // only do the following logic if the _httpClient doesn't have a base address already
-            // we should remove this if we update the ctor to always have a baseAddress
-            if (_httpClient.BaseAddress == null)
+            // if the request uri is not absolute, use the base uri
+            if (!requestUri.IsAbsoluteUri)
             {
-                // if the request uri is not absolute, use the base uri
-                if (!requestUri.IsAbsoluteUri)
+                if (_baseAddress != null)
                 {
-                    if (_baseAddress == null)
+                    requestUri = new Uri(_baseAddress, requestUri);
+                }
+                else
+                {
+                    // only do the following logic if the _httpClient doesn't have a base address already
+                    // we should remove this if we update the ctor to always have a baseAddress
+
+                    if (_httpClient.BaseAddress == null)
                     {
                         throw new InvalidOperationException(
                             "An invalid request URI was provided. The request URI must either be an absolute URI or BaseAddress must be set.");
                     }
 
-                    requestUri = new Uri(_baseAddress, requestUri);
+                    requestUri = new Uri(_httpClient.BaseAddress, requestUri);
                 }
             }
 

--- a/src/RestClient/RestClient/test/ClickView.Extensions.RestClient.Tests.csproj
+++ b/src/RestClient/RestClient/test/ClickView.Extensions.RestClient.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\ClickView.Extensions.RestClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/RestClient/RestClient/test/ClickView.Extensions.RestClient.Tests.csproj
+++ b/src/RestClient/RestClient/test/ClickView.Extensions.RestClient.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/RestClient/RestClient/test/RestClientTests.cs
+++ b/src/RestClient/RestClient/test/RestClientTests.cs
@@ -1,0 +1,128 @@
+namespace ClickView.Extensions.RestClient.Tests
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Moq;
+    using Moq.Protected;
+    using Requests;
+    using Xunit;
+
+    public class RestClientTests
+    {
+        [Fact]
+        public async Task ExecuteAsync_UsesBaseAddress()
+        {
+            // setup message handler
+            var mockMessageHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            mockMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(message =>
+                        message.RequestUri.Equals(new Uri("http://clickview.com.au/v1/test"))),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("test"),
+                })
+                .Verifiable();
+
+            // arrange
+            var request = new RestClientRequest(HttpMethod.Get, "v1/test");
+            var client = new RestClient(new Uri("http://clickview.com.au"), new HttpClient(mockMessageHandler.Object));
+
+            // act
+            await client.ExecuteAsync(request);
+
+            // assert
+            mockMessageHandler.Verify();
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_UsesHttpClientBaseAddress()
+        {
+            // setup message handler
+            var mockMessageHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            mockMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(message =>
+                        message.RequestUri.Equals(new Uri("https://hello.hello/test"))),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("test"),
+                })
+                .Verifiable();
+
+            // arrange
+            var request = new RestClientRequest(HttpMethod.Get, "test");
+            var client = new RestClient(new HttpClient(mockMessageHandler.Object)
+            {
+                BaseAddress = new Uri("https://hello.hello")
+            });
+
+            // act
+            await client.ExecuteAsync(request);
+
+            // assert
+            mockMessageHandler.Verify();
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_AbsoluteUriRequest()
+        {
+            // setup message handler
+            var mockMessageHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            mockMessageHandler.Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.Is<HttpRequestMessage>(message =>
+                        message.RequestUri.Equals(new Uri("https://clockview.clocks/test"))),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(new HttpResponseMessage
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent("test"),
+                })
+                .Verifiable();
+
+            // arrange
+            var request = new RestClientRequest(HttpMethod.Get, "https://clockview.clocks/test");
+            var client = new RestClient(new HttpClient(mockMessageHandler.Object)
+            {
+                BaseAddress = new Uri("https://hello.hello")
+            });
+
+            // act
+            await client.ExecuteAsync(request);
+
+            // assert
+            mockMessageHandler.Verify();
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_NoBaseAddress_ThrowsInvalidOperationException()
+        {
+            // setup message handler
+            var mockMessageHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+            // arrange
+            var request = new RestClientRequest(HttpMethod.Get, "test");
+            var client = new RestClient(new HttpClient(mockMessageHandler.Object));
+
+            // act/assert
+            await Assert.ThrowsAsync<InvalidOperationException>(() => client.ExecuteAsync(request));
+        }
+    }
+}


### PR DESCRIPTION
Updated the RestClient to build absolute urls internally instead of relying on the HttpClient to do so. This means that we can ensure that our `baseAddress` is used over a passed in `HttpClient.BaseAddress`


- Added another constructor overload 

```c#
public RestClient(Uri baseAddress, HttpClient httpClient, CoreRestClientOptions options = null)
```

- Added null checking in the constructors
- Moved options from overloads to nullable objects