### PR TITLE
obsolete old hosting classes

### DIFF
--- a/src/Hosting/Hosting/src/ConsoleHost.cs
+++ b/src/Hosting/Hosting/src/ConsoleHost.cs
@@ -1,11 +1,13 @@
 ﻿namespace ClickView.Extensions.Hosting
 {
+    using System;
     using System.IO;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
 
+    [Obsolete("Use the built in .NET Generic Host instead")]
     public static class ConsoleHost
     {
         public static IHostBuilder CreateDefaultBuilder(string[] args) =>

--- a/src/Hosting/Hosting/src/ConsoleHostOptions.cs
+++ b/src/Hosting/Hosting/src/ConsoleHostOptions.cs
@@ -1,5 +1,8 @@
 ﻿namespace ClickView.Extensions.Hosting
 {
+    using System;
+
+    [Obsolete("Use the built in .NET Generic Host instead")]
     public class ConsoleHostOptions
     {
         public string EnvironmentVariablesPrefix { get; set; } = "NETCORE";

--- a/src/Hosting/Hosting/src/Internal/Win32.cs
+++ b/src/Hosting/Hosting/src/Internal/Win32.cs
@@ -1,9 +1,10 @@
-﻿namespace ClickView.Extensions.Hosting.Internal
+namespace ClickView.Extensions.Hosting.Internal
 {
     using System;
     using System.Diagnostics;
     using System.Runtime.InteropServices;
 
+    [Obsolete("Use the built in .NET Generic Host instead")]
     internal static class Win32
     {
         // https://docs.microsoft.com/en-us/windows/desktop/api/tlhelp32/nf-tlhelp32-createtoolhelp32snapshot

--- a/src/Hosting/Hosting/src/ServiceBaseLifetime.cs
+++ b/src/Hosting/Hosting/src/ServiceBaseLifetime.cs
@@ -1,4 +1,4 @@
-﻿namespace ClickView.Extensions.Hosting
+namespace ClickView.Extensions.Hosting
 {
     using System;
     using System.ServiceProcess;
@@ -7,6 +7,7 @@
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
 
+    [Obsolete("Use the built in .NET Generic Host instead")]
     public class ServiceBaseLifetime : ServiceBase, IHostLifetime
     {
         private readonly TaskCompletionSource<object> _delayStart = new TaskCompletionSource<object>();

--- a/src/Hosting/Hosting/src/ServiceBaseLifetimeHostBuilderExtensions.cs
+++ b/src/Hosting/Hosting/src/ServiceBaseLifetimeHostBuilderExtensions.cs
@@ -8,6 +8,7 @@
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
 
+    [Obsolete("Use the built in .NET Generic Host instead")]
     public static class ServiceBaseLifetimeHostBuilderExtensions
     {
         /// <summary>


### PR DESCRIPTION
We should use the now built in .NET Generic Host