### PR TITLE
Enable nullable in the hosting project and fix null warnings

### DIFF
--- a/src/Hosting/Hosting/src/ClickView.Extensions.Hosting.csproj
+++ b/src/Hosting/Hosting/src/ClickView.Extensions.Hosting.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>1.3.0</Version>
-    <LangVersion>7.1</LangVersion>
+    <Nullable>enable</Nullable>
+    <LangVersion>8.0</LangVersion>
     <PackageTags>hosting</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Company>ClickView</Company>

--- a/src/Hosting/Hosting/src/Internal/Win32.cs
+++ b/src/Hosting/Hosting/src/Internal/Win32.cs
@@ -22,7 +22,7 @@
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool CloseHandle([In] IntPtr hObject);
 
-        internal static Process GetParentProcess()
+        internal static Process? GetParentProcess()
         {
             var snapshotHandle = IntPtr.Zero;
             try

--- a/src/Hosting/Hosting/src/ServiceBaseLifetime.cs
+++ b/src/Hosting/Hosting/src/ServiceBaseLifetime.cs
@@ -9,7 +9,7 @@
 
     public class ServiceBaseLifetime : ServiceBase, IHostLifetime
     {
-        private readonly TaskCompletionSource<object> _delayStart = new TaskCompletionSource<object>();
+        private readonly TaskCompletionSource<object?> _delayStart = new TaskCompletionSource<object?>();
 
         public ServiceBaseLifetime(IHostEnvironment environment, IHostApplicationLifetime applicationLifetime, ILoggerFactory loggerFactory)
         {

--- a/src/Hosting/Hosting/src/Workers/Worker.cs
+++ b/src/Hosting/Hosting/src/Workers/Worker.cs
@@ -8,8 +8,8 @@
     public abstract class Worker : IHostedService
     {
         private readonly ILogger _logger;
-        private Task _executingTask;
-        private CancellationTokenSource _cts;
+        private Task? _executingTask;
+        private CancellationTokenSource? _cts;
 
         protected Worker(ILogger logger)
         {
@@ -47,12 +47,17 @@
             _logger.LogInformation("Stopping Worker {WorkerName}...", Name);
 
             // Signal cancellation to the executing method
-            _cts.Cancel();
+            _cts?.Cancel();
 
             // Wait until the task completes or the stop token triggers
             await Task.WhenAny(_executingTask, Task.Delay(-1, cancellationToken)).ConfigureAwait(false);
 
             _logger.LogInformation("Worker {WorkerName} stopped", Name);
+
+            // Dispose our CancellationTokenSource and cleanup
+            _cts?.Dispose();
+            _cts = null;
+            _executingTask = null;
 
             // Throw if cancellation triggered
             cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
- Enable nullable references for `ClickView.Extensions.Hosting`
  - Fix null warnings
- Ensure that the Worker class is cleaned up when stopped