### PR TITLE
Threadinghelper Func Argument overload

### DIFF
--- a/src/Utilities/Utilities/src/Threading/ThreadingHelper.cs
+++ b/src/Utilities/Utilities/src/Threading/ThreadingHelper.cs
@@ -8,9 +8,17 @@ using Primitives.Extensions;
 
 public static class ThreadingHelper
 {
+    // Default to 4 because:
+    // 1 = May as well use a normal loop
+    // 2 = Not much better than 1
+    // 3/4 = Good candidate
+    // >5 = Probably too many for a default. If you need more you can pass it in
+    // Ended up choosing 4 because I like even numbers
+    private const int DefaultConcurrentTasks = 4;
+
     public static Task<TOut[]> ProcessAsync<TIn, TOut>(IEnumerable<TIn> source,
         Func<TIn, CancellationToken, Task<TOut>> func,
-        int concurrentTasks = 1,
+        int concurrentTasks = DefaultConcurrentTasks,
         CancellationToken cancellationToken = default)
     {
         return ProcessAsync(source, LocalFunc, func, concurrentTasks, cancellationToken);
@@ -22,7 +30,7 @@ public static class ThreadingHelper
     public static async Task<TOut[]> ProcessAsync<TIn, TArg, TOut>(IEnumerable<TIn> source,
         Func<TIn, TArg, CancellationToken, Task<TOut>> func,
         TArg funcArgument,
-        int concurrentTasks = 1,
+        int concurrentTasks = DefaultConcurrentTasks,
         CancellationToken cancellationToken = default)
     {
         if (source is null)

--- a/src/Utilities/Utilities/test/ClickView.Extensions.Utilities.Tests/Threading/TaskExtensions.cs
+++ b/src/Utilities/Utilities/test/ClickView.Extensions.Utilities.Tests/Threading/TaskExtensions.cs
@@ -1,0 +1,19 @@
+namespace ClickView.Extensions.Utilities.Tests.Threading;
+
+using System;
+using System.Threading.Tasks;
+
+internal static class TaskExtensions
+{
+    public static async Task IgnoreOperationCanceled(this Task task)
+    {
+        try
+        {
+            await task;
+        }
+        catch (OperationCanceledException)
+        {
+            // ignore
+        }
+    }
+}

--- a/src/Utilities/Utilities/test/ClickView.Extensions.Utilities.Tests/Threading/ThreadingHelperTests.cs
+++ b/src/Utilities/Utilities/test/ClickView.Extensions.Utilities.Tests/Threading/ThreadingHelperTests.cs
@@ -1,0 +1,81 @@
+namespace ClickView.Extensions.Utilities.Tests.Threading;
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Utilities.Threading;
+using Xunit;
+
+public class ThreadingHelperTests
+{
+    [Fact]
+    public async Task ProcessAsync_MoreItemsThanConcurrentTasks_LimitedToConcurrentTasks()
+    {
+        const int concurrency = 2;
+        var taskCount = 0;
+
+        // Create a list of more than 'concurrency' items
+        var items = Enumerable.Range(0, concurrency + 1);
+
+        using var cancellation = new CancellationTokenSource();
+
+        var task = ThreadingHelper.ProcessAsync(items, ProcessFunc, concurrency, cancellation.Token);
+
+        // wait until both tasks have started
+        await Task.Delay(10, CancellationToken.None);
+
+        // Check only our expected task number of tasks are running
+        Assert.Equal(concurrency, taskCount);
+
+        // Cleanup
+        cancellation.Cancel();
+        await task.IgnoreOperationCanceled();
+
+        return;
+
+        async Task<int> ProcessFunc(int x, CancellationToken y)
+        {
+            Interlocked.Increment(ref taskCount);
+            // 1000 delay to ensure we have a timeout
+            await Task.Delay(1000, y);
+            Interlocked.Decrement(ref taskCount);
+            return x;
+        }
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ProcessesAllTasks()
+    {
+        const int concurrency = 4;
+        const int totalTasks = 20;
+        var taskCount = 0;
+
+        // Create a list of more than 2 items
+        var items = Enumerable.Range(0, totalTasks);
+
+        var taskCounts = await ThreadingHelper.ProcessAsync(items, ProcessFunc, concurrency, CancellationToken.None);
+
+        // Check that we ran all tasks
+        Assert.Equal(totalTasks, taskCounts.Length);
+
+        // Check that we never had more than 'concurrency' tasks running
+        Assert.Equal(concurrency, taskCounts.Max());
+
+        return;
+
+        async Task<int> ProcessFunc(int x, CancellationToken y)
+        {
+            // Increment the task count and keep a reference to the current number
+            var currentTasks = Interlocked.Increment(ref taskCount);
+
+            // Simulate work
+            await Task.Delay(10, y);
+
+            // Reduce task count
+            Interlocked.Decrement(ref taskCount);
+
+            // Return the current task count we saw so we can check this value
+            return currentTasks;
+        }
+    }
+}


### PR DESCRIPTION
- Added overload to `ThreadingHelper.ProcessAsync` which allows passing in an argument for the function to avoid the closure allocation
- Increased the default `concurrentTasks` from 1 to 4