### PR TITLE
handle 429 error code and throw too many request exception

### DIFF
--- a/src/RestClient/RestClient/src/Exceptions/Http/TooManyRequestException.cs
+++ b/src/RestClient/RestClient/src/Exceptions/Http/TooManyRequestException.cs
@@ -1,0 +1,16 @@
+﻿namespace ClickView.Extensions.RestClient.Exceptions.Http;
+
+using System;
+using System.Net;
+
+public class TooManyRequestException : ClickViewClientHttpException
+{
+    public TooManyRequestException(HttpStatusCode httpStatusCode, string message) : base(httpStatusCode, message)
+    {
+    }
+
+    public TooManyRequestException(HttpStatusCode httpStatusCode, string message, Exception innerException) :
+        base(httpStatusCode, message, innerException)
+    {
+    }
+}

--- a/src/RestClient/RestClient/src/Helpers/ErrorHelper.cs
+++ b/src/RestClient/RestClient/src/Helpers/ErrorHelper.cs
@@ -32,6 +32,12 @@
             var message = error.Body.Message;
             var statusCode = error.HttpStatusCode;
 
+            // HttpStatusCode.TooManyRequests enum value was added in later version of .net
+            // such as net standard 2.1 and .net core 2.1 and above. So it is not available
+            // in full fat .net framework 4.6.2 
+            if ((int)statusCode == 429)
+                return new TooManyRequestException(statusCode, message);
+
             switch (error.HttpStatusCode)
             {
                 //errors to do with bad user input


### PR DESCRIPTION
Check on 429 http status code and throw a custom `TooManyRequestException` so the caller can catch and handle it.