### PR TITLE
Update target frameworks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,8 +14,18 @@
         <Version>1.5.0-rc4</Version>
     </PropertyGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="$(AssemblyName).Tests" />
+    </ItemGroup>
+
     <PropertyGroup>
         <LangVersion>12.0</LangVersion>
         <WarningsAsErrors>nullable</WarningsAsErrors>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <CoreTargetFrameworks>net8.0</CoreTargetFrameworks>
+        <FullTargetFrameworks>net462;netstandard2.0;net8.0</FullTargetFrameworks>
+        <TestTargetFrameworks>net8.0</TestTargetFrameworks>
     </PropertyGroup>
 </Project>

--- a/src/Events/Events/src/ClickView.Extensions.Events.csproj
+++ b/src/Events/Events/src/ClickView.Extensions.Events.csproj
@@ -1,16 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(FullTargetFrameworks)</TargetFrameworks>
     <PackageTags>events</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <InternalsVisibleTo Include="$(AssemblyName).Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/Events/Events/test/ClickView.Extensions.Events.Tests.csproj
+++ b/src/Events/Events/test/ClickView.Extensions.Events.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Hosting/Hosting/src/ClickView.Extensions.Hosting.csproj
+++ b/src/Hosting/Hosting/src/ClickView.Extensions.Hosting.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(FullTargetFrameworks)</TargetFrameworks>
     <Nullable>enable</Nullable>
     <PackageTags>hosting</PackageTags>
   </PropertyGroup>

--- a/src/Hosting/Hosting/test/ClickView.Extensions.Hosting.Tests/ClickView.Extensions.Hosting.Tests.csproj
+++ b/src/Hosting/Hosting/test/ClickView.Extensions.Hosting.Tests/ClickView.Extensions.Hosting.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/Primitives/Primitives/src/ClickView.Extensions.Primitives.csproj
+++ b/src/Primitives/Primitives/src/ClickView.Extensions.Primitives.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(FullTargetFrameworks)</TargetFrameworks>
     <PackageTags>primitives</PackageTags>
   </PropertyGroup>
 

--- a/src/Primitives/Primitives/src/Fraction.cs
+++ b/src/Primitives/Primitives/src/Fraction.cs
@@ -7,7 +7,7 @@
         public long Numerator { get; }
         public long Denominator { get; }
 
-        public static Fraction Empty = new Fraction();
+        public static readonly Fraction Empty = new Fraction();
 
         public Fraction(long numerator)
         {
@@ -21,12 +21,18 @@
             if (denominator == 0)
                 throw new ArgumentException("Invalid denominator value " + denominator, nameof(denominator));
 
+#if NET
             (Numerator, Denominator) = Simplify(numerator, denominator);
+#else
+            var result = Simplify(numerator, denominator);
+            Numerator = result.Item1;
+            Denominator = result.Item2;
+#endif
         }
 
         public static bool TryParse(string str, out Fraction fraction)
         {
-            return TryParse(str, new[] {'/', ':'}, out fraction);
+            return TryParse(str, ['/', ':'], out fraction);
         }
 
         public static bool TryParse(string str, char[] separators, out Fraction fraction)

--- a/src/Primitives/Primitives/test/ClickView.Extensions.Primitives.Tests.csproj
+++ b/src/Primitives/Primitives/test/ClickView.Extensions.Primitives.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/RestClient/Authenticators/OAuth/src/ClickView.Extensions.RestClient.Authenticators.OAuth.csproj
+++ b/src/RestClient/Authenticators/OAuth/src/ClickView.Extensions.RestClient.Authenticators.OAuth.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(FullTargetFrameworks)</TargetFrameworks>
     <PackageTags>restclient rest http oauth</PackageTags>
     <Description>OAuth authenticators for ClickView.Extensions.RestClient</Description>
   </PropertyGroup>

--- a/src/RestClient/Authenticators/OAuth/test/ClickView.Extensions.RestClient.Authenticators.OAuth.Tests.csproj
+++ b/src/RestClient/Authenticators/OAuth/test/ClickView.Extensions.RestClient.Authenticators.OAuth.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/RestClient/RestClient/src/ClickView.Extensions.RestClient.csproj
+++ b/src/RestClient/RestClient/src/ClickView.Extensions.RestClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net462</TargetFrameworks>
+    <TargetFrameworks>$(FullTargetFrameworks)</TargetFrameworks>
     <PackageTags>restclient rest http</PackageTags>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/RestClient/RestClient/test/ClickView.Extensions.RestClient.Tests.csproj
+++ b/src/RestClient/RestClient/test/ClickView.Extensions.RestClient.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Utilities/Utilities/src/ClickView.Extensions.Utilities.csproj
+++ b/src/Utilities/Utilities/src/ClickView.Extensions.Utilities.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>$(FullTargetFrameworks)</TargetFrameworks>
     <PackageTags>utilities</PackageTags>
   </PropertyGroup>
 

--- a/src/Utilities/Utilities/test/ClickView.Extensions.Utilities.Tests/ClickView.Extensions.Utilities.Tests.csproj
+++ b/src/Utilities/Utilities/test/ClickView.Extensions.Utilities.Tests/ClickView.Extensions.Utilities.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>$(TestTargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
- Update all projects to use a target framework defined in `Directory.Build.props`
- Update all projects to target `.net8.0` and drop support for `.net6.0`
- Update projects that target `netstandard2.0` to also target `.net462`