### PR TITLE
Update RestClient serialization logic

### DIFF
--- a/src/RestClient/RestClient/src/ContentTypes.cs
+++ b/src/RestClient/RestClient/src/ContentTypes.cs
@@ -1,0 +1,8 @@
+namespace ClickView.Extensions.RestClient;
+
+using System.Net.Http.Headers;
+
+internal class ContentTypes
+{
+    internal static MediaTypeHeaderValue OctetStream = new("application/octet-stream");
+}

--- a/src/RestClient/RestClient/src/Requests/BaseRestClientRequest.cs
+++ b/src/RestClient/RestClient/src/Requests/BaseRestClientRequest.cs
@@ -85,7 +85,8 @@ namespace ClickView.Extensions.RestClient.Requests
                 Parameters.Add(key, list);
             }
 
-            list.AddRange(values.Select(v => new RequestParameterValue(v, RequestParameterType.Query)));
+            foreach (var value in values)
+                list.Add(new RequestParameterValue(value, RequestParameterType.Query));
         }
 
         internal async Task<TResponse> GetResponseAsync(HttpResponseMessage message)

--- a/src/RestClient/RestClient/src/RestClient.cs
+++ b/src/RestClient/RestClient/src/RestClient.cs
@@ -110,7 +110,7 @@
                 httpRequest.Headers.TryAddWithoutValidation(h.Key, h.Value);
             }
 
-            SetContent(httpRequest, request);
+            httpRequest.Content = GetContent(request);
 
             try
             {
@@ -123,20 +123,19 @@
             }
         }
 
-        internal void SetContent<TResponse>(HttpRequestMessage httpRequest, BaseRestClientRequest<TResponse> request)
+        private HttpContent? GetContent<TResponse>(BaseRestClientRequest<TResponse> request)
             where TResponse : RestClientResponse
         {
-            if (request.Content == null)
-                return;
+            var content = request.GetContent();
 
-            if (_options.CompressionMethod == CompressionMethod.None)
-            {
-                httpRequest.Content = request.Content;
-                return;
-            }
+            if (content is null)
+                return null;
 
-            //we need to compress
-            request.Content = new CompressedContent(request.Content, _options.CompressionMethod);
+            // Do we need to compress the content?
+            if (_options.CompressionMethod != CompressionMethod.None)
+                return new CompressedContent(content, _options.CompressionMethod);
+
+            return content;
         }
 
         private static HttpClient CreateClient(RestClientOptions options)

--- a/src/RestClient/RestClient/test/RestClientRequestTests.cs
+++ b/src/RestClient/RestClient/test/RestClientRequestTests.cs
@@ -1,0 +1,95 @@
+namespace ClickView.Extensions.RestClient.Tests;
+
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Requests;
+using Serialization;
+using Xunit;
+
+public class RestClientRequestTests
+{
+    [Fact]
+    public void GetContent_NoBody_ReturnsNull()
+    {
+        var request = new RestClientRequest(HttpMethod.Post, "test");
+        Assert.Null(request.GetContent());
+    }
+
+    [Fact]
+    public async Task GetContent_StreamBody_ReturnsStreamContent()
+    {
+        var request = new RestClientRequest(HttpMethod.Post, "test");
+        request.AddBody(new MemoryStream([1,2,3]));
+
+        var result = request.GetContent();
+
+        var streamContent = Assert.IsType<StreamContent>(result);
+        var bytes = await streamContent.ReadAsByteArrayAsync();
+        Assert.Equal(streamContent.Headers.ContentType, MediaTypeHeaderValue.Parse("application/octet-stream"));
+        Assert.Equal([1, 2, 3], bytes);
+    }
+
+    [Fact]
+    public async Task GetContent_StreamBodyContentType_ReturnsStreamContent()
+    {
+        var request = new RestClientRequest(HttpMethod.Post, "test");
+        request.AddBody(new MemoryStream([1, 2, 3]), new MediaTypeHeaderValue("application/test"));
+
+        var result = request.GetContent();
+
+        var streamContent = Assert.IsType<StreamContent>(result);
+        var bytes = await streamContent.ReadAsByteArrayAsync();
+        Assert.Equal(streamContent.Headers.ContentType, MediaTypeHeaderValue.Parse("application/test"));
+        Assert.Equal([1, 2, 3], bytes);
+    }
+
+    [Fact]
+    public async Task GetContent_ObjectBody_ReturnsStringContent()
+    {
+        var request = new RestClientRequest(HttpMethod.Post, "test")
+        {
+            Serializer = new TestSerializer()
+        };
+        request.AddBody("hello world");
+
+        var result = request.GetContent();
+
+        var streamContent = Assert.IsType<StringContent>(result);
+        var resultString = await streamContent.ReadAsStringAsync();
+
+        Assert.Equal("hello world", resultString);
+        Assert.Equal("application/test", streamContent.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public void AddBody_GetRequest_ThrowsException()
+    {
+        var request = new RestClientRequest(HttpMethod.Get, "test");
+
+        var ex = Assert.Throws<Exception>(() => request.AddBody(1));
+        Assert.Equal("Cannot add body to GET", ex.Message);
+    }
+
+    private class TestSerializer : ISerializer
+    {
+        public string Format => "test";
+
+        public string Serialize(object obj)
+        {
+            return obj.ToString() ?? "";
+        }
+
+        public T? Deserialize<T>(string input)
+        {
+            throw new NotImplementedException();
+        }
+
+        public object? Deserialize(string input, Type type)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Previously, serialization of data was performed in `AddBody(object)` which meant that if you called `AddBody(object)` before setting a new `Serializer`, it would use the default serializer which isn't very clear. 

This PR updates this so now serialization happens when calling `ExecuteAsync` on the `RestClient`.

`AddBody(object)` and `AddBody(Stream)` are now effectively the same thing