### PR TITLE
New enumerable extensions

### DIFF
--- a/src/Primitives/Primitives/src/Extensions/EnumerableExtensions.cs
+++ b/src/Primitives/Primitives/src/Extensions/EnumerableExtensions.cs
@@ -1,4 +1,4 @@
-namespace ClickView.Extensions.Primitives.Extensions
+﻿namespace ClickView.Extensions.Primitives.Extensions
 {
     using System;
     using System.Collections;
@@ -62,6 +62,36 @@ namespace ClickView.Extensions.Primitives.Extensions
                 return collection;
 
             return new ReadOnlyCollection<T>(enumerable.ToList());
+        }
+
+        public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> enumerable) where T : class
+        {
+            if (enumerable is null)
+                throw new ArgumentNullException(nameof(enumerable));
+
+            foreach (var t in enumerable)
+            {
+                if (t is not null)
+                    yield return t;
+            }
+        }
+
+        public static IEnumerable<TResult> WhereNotNull<T, TResult>(
+            this IEnumerable<T> enumerable,
+            Func<T, TResult?> selector)
+            where TResult : class
+        {
+            if (enumerable is null)
+                throw new ArgumentNullException(nameof(enumerable));
+
+            if (selector is null)
+                throw new ArgumentNullException(nameof(selector));
+
+            foreach (var t in enumerable.Select(selector))
+            {
+                if (t is not null)
+                    yield return t;
+            }
         }
     }
 }

--- a/src/Primitives/Primitives/src/Extensions/EnumerableExtensions.cs
+++ b/src/Primitives/Primitives/src/Extensions/EnumerableExtensions.cs
@@ -61,7 +61,7 @@ namespace ClickView.Extensions.Primitives.Extensions
             if (enumerable is IReadOnlyList<T> collection)
                 return collection;
 
-            return enumerable.ToList();
+            return new ReadOnlyCollection<T>(enumerable.ToList());
         }
     }
 }

--- a/src/Primitives/Primitives/src/Extensions/EnumerableExtensions.cs
+++ b/src/Primitives/Primitives/src/Extensions/EnumerableExtensions.cs
@@ -9,6 +9,14 @@
 
     public static partial class EnumerableExtensions
     {
+        /// <summary>
+        /// Tries to get the first element of a sequence
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="value">The first element if found</param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>True if element contains an item, otherwise false</returns>
+        /// <exception cref="ArgumentNullException"></exception>
         public static bool TryGetFirstValue<T>(this IEnumerable<T> source, [MaybeNullWhen(false)] out T value)
         {
             if (source is null)
@@ -48,6 +56,12 @@
             return true;
         }
 
+        /// <summary>
+        /// Casts a sequence to an <see cref="ICollection{T}"/>, otherwise enumerates the sequence.
+        /// </summary>
+        /// <param name="enumerable"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
         public static ICollection<T> AsCollection<T>(this IEnumerable<T> enumerable)
         {
             if (enumerable is ICollection<T> collection)
@@ -56,6 +70,12 @@
             return enumerable.ToList();
         }
 
+        /// <summary>
+        /// Casts a sequence to a <see cref="IReadOnlyList{T}"/>, otherwise enumerates the sequence.
+        /// </summary>
+        /// <param name="enumerable"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
         public static IReadOnlyList<T> AsReadOnlyList<T>(this IEnumerable<T> enumerable)
         {
             if (enumerable is IReadOnlyList<T> collection)
@@ -64,6 +84,13 @@
             return new ReadOnlyCollection<T>(enumerable.ToList());
         }
 
+        /// <summary>
+        /// Enumerates a sequence and returns only non null values
+        /// </summary>
+        /// <param name="enumerable"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
         public static IEnumerable<T> WhereNotNull<T>(this IEnumerable<T?> enumerable) where T : class
         {
             if (enumerable is null)
@@ -76,6 +103,15 @@
             }
         }
 
+        /// <summary>
+        /// Enumerates a sequence and returns only non null values
+        /// </summary>
+        /// <param name="enumerable"></param>
+        /// <param name="selector"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="TResult"></typeparam>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
         public static IEnumerable<TResult> WhereNotNull<T, TResult>(
             this IEnumerable<T> enumerable,
             Func<T, TResult?> selector)

--- a/src/Primitives/Primitives/test/Extensions/EnumerableExtensionTests.cs
+++ b/src/Primitives/Primitives/test/Extensions/EnumerableExtensionTests.cs
@@ -1,0 +1,16 @@
+namespace ClickView.Extensions.Primitives.Tests.Extensions;
+
+using Primitives.Extensions;
+using Xunit;
+
+public class EnumerableExtensionTests
+{
+    [Fact]
+    public void TryGetFirstValue()
+    {
+        int[] list = [1, 2, 3];
+
+        Assert.True(list.TryGetFirstValue(out var value));
+        Assert.Equal(1, value);
+    }
+}

--- a/src/Primitives/Primitives/test/Extensions/EnumerableExtensionTests.cs
+++ b/src/Primitives/Primitives/test/Extensions/EnumerableExtensionTests.cs
@@ -6,11 +6,38 @@ using Xunit;
 public class EnumerableExtensionTests
 {
     [Fact]
-    public void TryGetFirstValue()
+    public void TryGetFirstValue_Array()
     {
         int[] list = [1, 2, 3];
 
         Assert.True(list.TryGetFirstValue(out var value));
         Assert.Equal(1, value);
+    }
+
+    [Fact]
+    public void TryGetFirstValue_Enumerable()
+    {
+        // Where() to force an Enumerable
+        IEnumerable<int> list = Enumerable.Range(1, 100).Where(x => true);
+
+        Assert.True(list.TryGetFirstValue(out var value));
+        Assert.Equal(1, value);
+    }
+
+    [Fact]
+    public void TryGetFirstValue_Empty()
+    {
+        int[] list = [];
+
+        Assert.False(list.TryGetFirstValue(out _));
+    }
+
+    [Fact]
+    public void TryGetFirstValue_EmptyEnumerable()
+    {
+        // Where() to force an Enumerable
+        IEnumerable<int> list = Enumerable.Range(1, 100).Where(x => false);
+
+        Assert.False(list.TryGetFirstValue(out _));
     }
 }


### PR DESCRIPTION
- Add XMLDocs to `EnumerableExtensions`
- Add `WhereNotNull`
- When calling `AsReadOnlyList()`, if enumerating, return a `ReadOnlyCollection`
- Update `TryGetFirstValue()` to use `TryGetNonEnumeratedCount()` when using .net8