### PR TITLE
handle re-adding the header to the same request

### DIFF
--- a/src/RestClient/Authenticators/OAuth/src/OAuthAuthenticator.cs
+++ b/src/RestClient/Authenticators/OAuth/src/OAuthAuthenticator.cs
@@ -1,4 +1,4 @@
-﻿namespace ClickView.Extensions.RestClient.Authenticators.OAuth;
+namespace ClickView.Extensions.RestClient.Authenticators.OAuth;
 
 using System;
 using System.Collections.Generic;
@@ -56,7 +56,7 @@ public abstract class OAuthAuthenticator<TOptions> : IAuthenticator where TOptio
             return;
         }
 
-        request.AddHeader("Authorization", "Bearer " + oAuthToken);
+        request.AddOrUpdateHeader("Authorization", "Bearer " + oAuthToken);
     }
 
     protected void AddTokenSource(ITokenSource tokenSource)

--- a/src/RestClient/RestClient/src/Authentication/BasicAccessAuthenticator.cs
+++ b/src/RestClient/RestClient/src/Authentication/BasicAccessAuthenticator.cs
@@ -1,4 +1,4 @@
-﻿namespace ClickView.Extensions.RestClient.Authentication;
+namespace ClickView.Extensions.RestClient.Authentication;
 
 using System;
 using System.Text;
@@ -24,7 +24,7 @@ public class BasicAccessAuthenticator : IAuthenticator
 
     public Task AuthenticateAsync(IClientRequest request, CancellationToken token = default)
     {
-        request.AddHeader("Authorization", $"Basic {_encoded}");
+        request.AddOrUpdateHeader("Authorization", $"Basic {_encoded}");
         return Task.CompletedTask;
     }
 

--- a/src/RestClient/RestClient/src/Authentication/HeaderAuthenticator.cs
+++ b/src/RestClient/RestClient/src/Authentication/HeaderAuthenticator.cs
@@ -1,4 +1,4 @@
-﻿namespace ClickView.Extensions.RestClient.Authentication;
+namespace ClickView.Extensions.RestClient.Authentication;
 
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,7 +20,7 @@ public class HeaderAuthenticator : IAuthenticator
 
     public Task AuthenticateAsync(IClientRequest request, CancellationToken token = default)
     {
-        request.AddHeader(_key, _value);
+        request.AddOrUpdateHeader(_key, _value);
 
         return Task.CompletedTask;
     }

--- a/src/RestClient/RestClient/src/Requests/BaseRestClientRequest.cs
+++ b/src/RestClient/RestClient/src/Requests/BaseRestClientRequest.cs
@@ -37,11 +37,21 @@ public abstract class BaseRestClientRequest<TResponse>(HttpMethod method, string
 
     public void AddHeader(string key, string value)
     {
-        _headers.Remove(key);   // no-op if it does not exist
         _headers.Add(key, value);
     }
 
     public void AddHeader(string key, IEnumerable<string> values)
+    {
+        _headers.Add(key, values);
+    }
+
+    public void AddOrUpdateHeader(string key, string value)
+    {
+        _headers.Remove(key);   // no-op if it does not exist
+        _headers.Add(key, value);
+    }
+
+    public void AddOrUpdateHeader(string key, IEnumerable<string> values)
     {
         _headers.Remove(key);   // no-op if it does not exist
         _headers.Add(key, values);

--- a/src/RestClient/RestClient/src/Requests/BaseRestClientRequest.cs
+++ b/src/RestClient/RestClient/src/Requests/BaseRestClientRequest.cs
@@ -37,11 +37,13 @@ public abstract class BaseRestClientRequest<TResponse>(HttpMethod method, string
 
     public void AddHeader(string key, string value)
     {
+        _headers.Remove(key);   // no-op if it does not exist
         _headers.Add(key, value);
     }
 
     public void AddHeader(string key, IEnumerable<string> values)
     {
+        _headers.Remove(key);   // no-op if it does not exist
         _headers.Add(key, values);
     }
 
@@ -53,7 +55,7 @@ public abstract class BaseRestClientRequest<TResponse>(HttpMethod method, string
         _content = body;
         return;
 
-        bool MethodSupportsBody(HttpMethod method)
+        static bool MethodSupportsBody(HttpMethod method)
         {
             return method == HttpMethod.Post ||
 #if NETCOREAPP2_1_OR_GREATER

--- a/src/RestClient/RestClient/src/Requests/IClientRequest.cs
+++ b/src/RestClient/RestClient/src/Requests/IClientRequest.cs
@@ -11,5 +11,7 @@ public interface IClientRequest
 
     void AddHeader(string key, string value);
     void AddHeader(string key, IEnumerable<string> values);
+    void AddOrUpdateHeader(string key, string value);
+    void AddOrUpdateHeader(string key, IEnumerable<string> values);
     void AddBody(object body);
 }

--- a/src/RestClient/RestClient/src/RestClient.cs
+++ b/src/RestClient/RestClient/src/RestClient.cs
@@ -162,7 +162,6 @@ public class RestClient
 
         PrepareHttpClient(httpClient, options);
 
-
         return httpClient;
     }
 

--- a/src/RestClient/RestClient/test/RestClientRequestTests.cs
+++ b/src/RestClient/RestClient/test/RestClientRequestTests.cs
@@ -74,27 +74,27 @@ public class RestClientRequestTests
     }
 
     [Fact]
-    public void AddHeader_SingleValue_SameHeaderTwice_DoesNotThrow()
+    public void AddOrUpdateHeader_SingleValue_SameHeaderTwice_DoesNotThrow()
     {
         const string key = "X-Test-Header";
         const string value = "TestValue";
 
         var request = new RestClientRequest(HttpMethod.Post, "test");
-        request.AddHeader(key, value);
-        request.AddHeader(key, value);
+        request.AddOrUpdateHeader(key, value);
+        request.AddOrUpdateHeader(key, value);
 
         Assert.Single(request.Headers);
     }
 
     [Fact]
-    public void AddHeader_MultipleValues_SameHeaderTwice_DoesNotThrow()
+    public void AddOrUpdateHeader_MultipleValues_SameHeaderTwice_DoesNotThrow()
     {
         const string key = "X-Test-Header";
         string[] values = ["TestValue1", "TestValue2"];
 
         var request = new RestClientRequest(HttpMethod.Post, "test");
-        request.AddHeader(key, values);
-        request.AddHeader(key, values);
+        request.AddOrUpdateHeader(key, values);
+        request.AddOrUpdateHeader(key, values);
 
         Assert.Single(request.Headers);
     }

--- a/src/RestClient/RestClient/test/RestClientRequestTests.cs
+++ b/src/RestClient/RestClient/test/RestClientRequestTests.cs
@@ -73,6 +73,32 @@ public class RestClientRequestTests
         Assert.Equal("Cannot add body to GET", ex.Message);
     }
 
+    [Fact]
+    public void AddHeader_SingleValue_SameHeaderTwice_DoesNotThrow()
+    {
+        const string key = "X-Test-Header";
+        const string value = "TestValue";
+
+        var request = new RestClientRequest(HttpMethod.Post, "test");
+        request.AddHeader(key, value);
+        request.AddHeader(key, value);
+
+        Assert.Single(request.Headers);
+    }
+
+    [Fact]
+    public void AddHeader_MultipleValues_SameHeaderTwice_DoesNotThrow()
+    {
+        const string key = "X-Test-Header";
+        string[] values = ["TestValue1", "TestValue2"];
+
+        var request = new RestClientRequest(HttpMethod.Post, "test");
+        request.AddHeader(key, values);
+        request.AddHeader(key, values);
+
+        Assert.Single(request.Headers);
+    }
+
     private class TestSerializer : ISerializer
     {
         public string Format => "test";

--- a/src/RestClient/RestClient/test/RestClientTests.cs
+++ b/src/RestClient/RestClient/test/RestClientTests.cs
@@ -214,7 +214,7 @@ public class RestClientTests
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>()
             )
-            .Callback<HttpRequestMessage, CancellationToken>((request, token) =>
+            .Callback<HttpRequestMessage, CancellationToken>((request, _) =>
             {
                 userAgentHeader = request.Headers.UserAgent.ToString();
             })


### PR DESCRIPTION
* Fixed an issue where the `Authorization` header getting added multiple times throws exception when retry logic kicks in to execute the same request again